### PR TITLE
Add H1 walking env, generalize WalkingTask to be robot-agnostic

### DIFF
--- a/envs/__init__.py
+++ b/envs/__init__.py
@@ -5,7 +5,7 @@ This makes environments discoverable for testing and external use.
 """
 
 from envs.cartpole import CartpoleEnv
-from envs.h1 import H1Env
+from envs.h1 import H1Env, H1WalkEnv
 from envs.jvrc import JvrcStepEnv, JvrcWalkEnv
 
 # Registry of all available environments
@@ -14,6 +14,7 @@ ENVIRONMENTS = {
     "jvrc_walk": (JvrcWalkEnv, "jvrc"),
     "jvrc_step": (JvrcStepEnv, "jvrc"),
     "h1": (H1Env, "h1"),
+    "h1_walk": (H1WalkEnv, "h1"),
     "cartpole": (CartpoleEnv, "cartpole"),
 }
 
@@ -21,6 +22,7 @@ __all__ = [
     "JvrcWalkEnv",
     "JvrcStepEnv",
     "H1Env",
+    "H1WalkEnv",
     "CartpoleEnv",
     "ENVIRONMENTS",
 ]

--- a/envs/h1/__init__.py
+++ b/envs/h1/__init__.py
@@ -1,3 +1,4 @@
 from envs.h1.h1_env import H1Env
+from envs.h1.h1_walk import H1WalkEnv
 
-__all__ = ["H1Env"]
+__all__ = ["H1Env", "H1WalkEnv"]

--- a/envs/h1/configs/walk.yaml
+++ b/envs/h1/configs/walk.yaml
@@ -1,0 +1,58 @@
+sim_dt: 0.001
+control_dt: 0.025
+obs_history_len: 1
+action_smoothing: 0.5
+
+# Path for exporting generated MuJoCo XML files
+xml_export_path: /tmp/mjcf-export
+
+ctrllimited: false
+jointlimited: false
+reduced_xml: true
+
+init_noise: 3
+
+# Half-sitting pose in radians (legs only)
+half_sitting_pose: [0, 0, -0.2, 0.6, -0.4,
+                    0, 0, -0.2, 0.6, -0.4]
+
+pdgains:
+  "left_hip_yaw":   [100, 10]
+  "left_hip_roll":  [100, 10]
+  "left_hip_pitch": [100, 10]
+  "left_knee":      [100, 10]
+  "left_ankle":     [20, 4]
+  "right_hip_yaw":   [100, 10]
+  "right_hip_roll":  [100, 10]
+  "right_hip_pitch": [100, 10]
+  "right_knee":      [100, 10]
+  "right_ankle":     [20, 4]
+
+# Walking task parameters
+task:
+  goal_height: 1.0
+  total_duration: 0.5
+  swing_duration: 0.4
+  stance_duration: 0.1
+
+observation_noise:
+  enabled: true
+  multiplier: 1.0
+  type: "uniform"
+  scales:
+    root_orient: 0.05
+    root_ang_vel: 0.05
+    motor_pos: 0.02
+    motor_vel: 0.05
+    motor_tau: 5.0
+
+perturbation:
+  enable: true
+  bodies: ["pelvis", "torso_link"]
+  force_magnitude: 10
+  torque_magnitude: 2
+  interval: 5
+
+dynamics_randomization:
+  enable: true
+  interval: 0.5

--- a/envs/h1/h1_walk.py
+++ b/envs/h1/h1_walk.py
@@ -1,0 +1,174 @@
+"""H1 humanoid walking environment.
+
+Bootstraps a 3-mode walking policy (STANDING / INPLACE / FORWARD) on the
+H1 lower body. Used by itself for the walking expert and as the source
+policy for `--imitate` when training the mimic env.
+"""
+
+import os
+
+import mujoco
+import numpy as np
+import transforms3d as tf3
+
+from tasks import walking_task
+
+from .gen_xml import ARM_JOINTS, WAIST_JOINTS, builder
+from .h1_base import H1BaseEnv
+
+
+class H1WalkEnv(H1BaseEnv):
+    """Unitree H1 humanoid walking environment."""
+
+    def _get_default_config_path(self) -> str:
+        return os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/walk.yaml")
+
+    def _build_xml(self) -> str:
+        export_dir = self._get_xml_export_dir("h1_walk")
+        path_to_xml = os.path.join(export_dir, "h1.xml")
+        if not os.path.exists(path_to_xml):
+            builder(
+                export_dir,
+                config={
+                    "unused_joints": [WAIST_JOINTS, ARM_JOINTS],
+                    "rangefinder": False,
+                    "raisedplatform": False,
+                    "ctrllimited": self.cfg.ctrllimited,
+                    "jointlimited": self.cfg.jointlimited,
+                    "minimal": self.cfg.reduced_xml,
+                },
+            )
+        return path_to_xml
+
+    def _setup_task(self, control_dt: float) -> None:
+        task_cfg = self.cfg.task
+        self.task = walking_task.WalkingTask(
+            client=self.interface,
+            dt=control_dt,
+            neutral_pose=self.half_sitting_pose,
+            root_body="pelvis",
+            lfoot_body=self.LFOOT_BODY,
+            rfoot_body=self.RFOOT_BODY,
+            head_body="torso_link",
+        )
+        self.task._goal_height_ref = task_cfg.goal_height
+        self.task._total_duration = task_cfg.total_duration
+        self.task._swing_duration = task_cfg.swing_duration
+        self.task._stance_duration = task_cfg.stance_duration
+
+    def _setup_robot(self) -> None:
+        super()._setup_robot()
+        self._setup_mirror_indices()
+
+    def _setup_mirror_indices(self) -> None:
+        # Mirror indices over the 35-D robot state + 8-D external state.
+        # Order: root_orient(2), root_ang_vel(3), motor_pos(10), motor_vel(10),
+        # motor_tau(10), clock(2), mode_one_hot(3), mode_ref(3).
+        # Joint order in motor blocks: left(5) then right(5); within a leg:
+        # hip_yaw, hip_roll, hip_pitch, knee, ankle.
+        base_mir_obs = [
+            -0.1,
+            1,  # root orient (roll, pitch)
+            -2,
+            3,
+            -4,  # root ang vel
+            -10,
+            -11,
+            12,
+            13,
+            14,  # motor pos [1] -> right leg
+            -5,
+            -6,
+            7,
+            8,
+            9,  # motor pos [2] -> left leg
+            -20,
+            -21,
+            22,
+            23,
+            24,  # motor vel [1]
+            -15,
+            -16,
+            17,
+            18,
+            19,  # motor vel [2]
+            -30,
+            -31,
+            32,
+            33,
+            34,  # motor torque [1]
+            -25,
+            -26,
+            27,
+            28,
+            29,  # motor torque [2]
+        ]
+        num_ext = self._get_num_external_obs()
+        append_obs = [(len(base_mir_obs) + i) for i in range(num_ext)]
+        self.robot.clock_inds = append_obs[0:2]
+        self.robot.mirrored_obs = np.array(base_mir_obs + append_obs, copy=True).tolist()
+        # Action ordering: [left_leg(5), right_leg(5)]; mirror swaps and flips
+        # signs of yaw/roll dofs (idx 0,1).
+        self.robot.mirrored_acts = [-5, -6, 7, 8, 9, -0.1, -1, 2, 3, 4]
+
+    def _get_num_external_obs(self) -> int:
+        # clock(2) + mode_one_hot(3) + mode_ref(3) = 8
+        return 8
+
+    def _get_external_state(self) -> np.ndarray:
+        clock = [
+            np.sin(2 * np.pi * self.task._phase / self.task._period),
+            np.cos(2 * np.pi * self.task._phase / self.task._period),
+        ]
+        return np.concatenate((clock, self.task.mode.encode(), self.task.mode_ref))
+
+    def _setup_obs_normalization(self) -> None:
+        self.obs_mean = np.concatenate(
+            (
+                np.zeros(5),
+                self.half_sitting_pose,
+                np.zeros(10),
+                np.zeros(10),
+                [0, 0],
+                [0.5, 0.5, 0.5, 0, 0, 0],
+            )
+        )
+        self.obs_std = np.concatenate(
+            (
+                [0.2, 0.2, 1, 1, 1],
+                0.5 * np.ones(10),
+                4 * np.ones(10),
+                100 * np.ones(10),
+                [1, 1],
+                [1, 1, 1, 0.5, 0.5, 0.5],
+            )
+        )
+        self.obs_mean = np.tile(self.obs_mean, self.history_len)
+        self.obs_std = np.tile(self.obs_std, self.history_len)
+
+    def draw_markers(self, marker_drawer):
+        """Draw an arrow over the robot showing walking mode and reference."""
+        if not hasattr(self.task, "mode"):
+            return
+
+        arrow = mujoco.mjtGeom.mjGEOM_ARROW
+        head_pos = self.interface.get_object_xpos_by_name(self.task._head_body_name, "OBJ_BODY")
+        arrow_pos = [head_pos[0], head_pos[1], head_pos[2] + 0.5]
+
+        root_quat = self.interface.get_object_xquat_by_name(self.task._root_body_name, "OBJ_BODY")
+        root_yaw = tf3.euler.quat2euler(root_quat)[2]
+
+        mode = self.task.mode
+        yaw_ref, vx_ref, vy_ref = self.task.mode_ref
+        rgba_blue = np.array([0, 0, 1, 0.5])
+
+        if mode == walking_task.WalkModes.FORWARD:
+            length = float(np.linalg.norm([vx_ref, vy_ref]))
+            mat = tf3.euler.euler2mat(0, np.pi / 2, root_yaw)
+        elif mode == walking_task.WalkModes.INPLACE:
+            length = float(yaw_ref)
+            mat = tf3.euler.euler2mat(0, 0, 0)
+        else:
+            length = 0.0
+            mat = tf3.euler.euler2mat(0, np.pi, 0)
+        marker_drawer.add_marker(pos=arrow_pos, mat=mat, size=[0.05, 0.05, 2 * length], rgba=rgba_blue, type=arrow)

--- a/envs/jvrc/jvrc_walk.py
+++ b/envs/jvrc/jvrc_walk.py
@@ -30,7 +30,7 @@ class JvrcWalkEnv(JvrcBaseEnv):
             rfoot_body=self.RFOOT_BODY,
             head_body=self.HEAD_BODY,
         )
-        self.task._neutral_pose = self.nominal_pose
+        self.task._neutral_pose = np.deg2rad(self.half_sitting_pose)
 
         # Set task parameters from config
         task_cfg = self.cfg.task
@@ -40,19 +40,31 @@ class JvrcWalkEnv(JvrcBaseEnv):
         self.task._stance_duration = task_cfg.stance_duration
 
     def _get_num_external_obs(self) -> int:
-        return 6  # clock(2) + mode_encode(3) + mode_ref(1)
+        return 8  # clock(2) + mode_encode(3) + mode_ref(3)
 
     def _setup_obs_normalization(self) -> None:
         self.obs_mean = np.concatenate(
-            (np.zeros(5), np.deg2rad(self.half_sitting_pose), np.zeros(12), [0.5, 0.5, 0.5, 0, 0, 0])
+            (
+                np.zeros(5),
+                np.deg2rad(self.half_sitting_pose),
+                np.zeros(12),
+                [0, 0, 0.5, 0.5, 0.5, 0, 0, 0],
+            )
         )
-        self.obs_std = np.concatenate(([0.2, 0.2, 1, 1, 1], 0.5 * np.ones(12), 4 * np.ones(12), [1, 1, 1, 1, 1, 1]))
+        self.obs_std = np.concatenate(
+            (
+                [0.2, 0.2, 1, 1, 1],
+                0.5 * np.ones(12),
+                4 * np.ones(12),
+                [1, 1, 1, 1, 1, 0.5, 0.5, 0.5],
+            )
+        )
         self.obs_mean = np.tile(self.obs_mean, self.history_len)
         self.obs_std = np.tile(self.obs_std, self.history_len)
 
     def _get_external_state(self) -> np.ndarray:
         clock = self._get_clock_signal()
-        return np.concatenate((clock, self.task.mode.encode(), [self.task.mode_ref]))
+        return np.concatenate((clock, self.task.mode.encode(), self.task.mode_ref))
 
     def draw_markers(self, marker_drawer):
         """Draw an arrow above the robot's head indicating walking mode and reference."""
@@ -71,15 +83,15 @@ class JvrcWalkEnv(JvrcBaseEnv):
 
         # Determine arrow direction and size based on mode
         mode = self.task.mode
-        mode_ref = self.task.mode_ref
+        mode_ref = self.task.mode_ref  # [yaw_vel, vx, vy]
         rgba_blue = np.array([0, 0, 1, 0.5])
         rgba_green = np.array([0, 1, 0, 0.5])
 
         if mode == walking_task.WalkModes.FORWARD:
-            arrow_length = abs(mode_ref)
+            arrow_length = float(np.linalg.norm(mode_ref[1:3]))
             arrow_mat = tf3.euler.euler2mat(0, np.pi / 2, root_yaw)
         elif mode == walking_task.WalkModes.INPLACE:
-            arrow_length = mode_ref
+            arrow_length = float(mode_ref[0])
             arrow_mat = tf3.euler.euler2mat(0, 0, 0)
         else:  # STANDING
             arrow_length = 0.0

--- a/run_experiment.py
+++ b/run_experiment.py
@@ -91,6 +91,8 @@ def import_env(env_name_str):
         from envs.jvrc import JvrcStepEnv as Env
     elif env_name_str == "h1":
         from envs.h1 import H1Env as Env
+    elif env_name_str == "h1_walk":
+        from envs.h1 import H1WalkEnv as Env
     elif env_name_str == "cartpole":
         from envs.cartpole import CartpoleEnv as Env
     else:

--- a/tasks/rewards.py
+++ b/tasks/rewards.py
@@ -6,17 +6,20 @@ Functions return scalar reward values, typically in range [0, 1] for exponential
 import numpy as np
 
 
-def calc_fwd_vel_reward(root_vel: float, goal_speed: float) -> float:
-    """Reward for forward velocity tracking.
+def calc_fwd_vel_reward(root_vel, goal_speed) -> float:
+    """Reward for linear velocity tracking.
+
+    Accepts scalar (forward-only) or vector (planar) velocities. For vectors,
+    the error is the Euclidean norm of the difference.
 
     Args:
-        root_vel: Current forward velocity of the root body.
-        goal_speed: Target forward velocity.
+        root_vel: Current root velocity (scalar or 1-D array).
+        goal_speed: Target velocity (scalar or 1-D array of matching shape).
 
     Returns:
         Exponential reward based on velocity error.
     """
-    error = np.abs(root_vel - goal_speed)
+    error = np.linalg.norm(np.atleast_1d(root_vel) - np.atleast_1d(goal_speed))
     return np.exp(-10 * (error**2))
 
 

--- a/tasks/walking_task.py
+++ b/tasks/walking_task.py
@@ -1,3 +1,15 @@
+"""Generic mode-conditioned walking task for biped humanoids.
+
+3-mode command (STANDING / INPLACE / FORWARD) with a 3-D velocity reference
+[yaw_vel, vx, vy]. Mode-dependent zeroing is applied during reward
+computation, so unused dimensions of `mode_ref` are ignored.
+
+Designed to be robot-agnostic: robot-specific configuration (root/foot/head
+body names, gait timing, neutral pose) is supplied via __init__. For richer
+behavior (curriculum, custom mode-switching, custom termination), subclass
+WalkingTask.
+"""
+
 from enum import Enum, auto
 
 import numpy as np
@@ -19,17 +31,18 @@ class WalkModes(Enum):
         elif self.name == "FORWARD":
             return np.array([1, 0, 0])
 
-    def sample_ref(self):
+    def sample_ref(self) -> np.ndarray:
+        """Sample a 3-D velocity reference [yaw_vel, vx, vy]."""
         if self.name == "STANDING":
-            return np.random.uniform(-1, 1)
+            return np.random.uniform(-1.0, 1.0, 3)
         if self.name == "INPLACE":
-            return np.random.uniform(-0.5, 0.5)
+            return np.array([np.random.uniform(-0.5, 0.5), 0.0, 0.0])
         if self.name == "FORWARD":
-            return np.random.uniform(0.0, 0.4)
+            return np.array([0.0, np.random.uniform(0.0, 0.4), 0.0])
 
 
 class WalkingTask(BaseTask):
-    """Dynamically stable walking on biped."""
+    """Mode-conditioned walking task for biped humanoids."""
 
     def __init__(
         self,
@@ -41,8 +54,6 @@ class WalkingTask(BaseTask):
         lfoot_body="lfoot",
         rfoot_body="rfoot",
         head_body="head",
-        waist_r_joint="waist_r",
-        waist_p_joint="waist_p",
         manip_hfield=False,
     ):
         if neutral_foot_orient is None:
@@ -58,8 +69,8 @@ class WalkingTask(BaseTask):
 
         self._mass = self._client.get_robot_mass()
 
-        # These depend on the robot, hardcoded for now
-        # Ideally, they should be arguments to __init__
+        # Set by the env after construction; left empty here so subclasses
+        # / envs can populate from config.
         self.mode_ref = []
         self._goal_height_ref = []
         self._swing_duration = []
@@ -80,20 +91,18 @@ class WalkingTask(BaseTask):
         head_pos = self._client.get_object_xpos_by_name(self._head_body_name, "OBJ_BODY")[0:2]
         root_pos = self._client.get_object_xpos_by_name(self._root_body_name, "OBJ_BODY")[0:2]
         root_height = self._client.get_object_xpos_by_name(self._root_body_name, "OBJ_BODY")[2]
-        root_vel = self._client.get_body_vel(self._root_body_name, frame=1)[0][0]
+        root_vel_xy = self._client.get_body_vel(self._root_body_name, frame=1)[0][:2]
         yaw_vel = self._client.get_qvel()[5]
         qvel = self._client.get_qvel()
         qacc = self._client.get_qacc()
         current_torque = np.asarray(self._client.get_act_joint_torques())
-        current_pose = np.array(self._client.get_act_joint_positions())
+        n_joints = len(self._neutral_pose)
+        current_pose = np.array(self._client.get_act_joint_positions())[:n_joints]
 
         # Get contact point for height calculation
         if self._client.check_rfoot_floor_collision() or self._client.check_lfoot_floor_collision():
             contact_point_z = min(
-                [
-                    c.pos[2]
-                    for _, c in (self._client.get_rfoot_floor_contacts() + self._client.get_lfoot_floor_contacts())
-                ]
+                c.pos[2] for _, c in (self._client.get_rfoot_floor_contacts() + self._client.get_lfoot_floor_contacts())
             )
         else:
             contact_point_z = 0
@@ -109,18 +118,17 @@ class WalkingTask(BaseTask):
             r_vel_fn = lambda _: -1
             l_vel_fn = lambda _: -1
 
-        # Determine speed/yaw targets based on mode
+        # Decompose 3-D mode_ref [yaw_vel, vx, vy] and apply mode-dependent zeroing
+        yaw_vel_ref, vx_ref, vy_ref = self.mode_ref
         if self.mode == WalkModes.STANDING:
-            self._goal_speed_ref = 0
-            yaw_vel_ref = 0
-        if self.mode == WalkModes.INPLACE:
-            self._goal_speed_ref = 0
-            yaw_vel_ref = self.mode_ref
-        if self.mode == WalkModes.FORWARD:
-            self._goal_speed_ref = self.mode_ref
-            yaw_vel_ref = 0
+            yaw_vel_ref, vx_ref, vy_ref = 0.0, 0.0, 0.0
+        elif self.mode == WalkModes.INPLACE:
+            vx_ref, vy_ref = 0.0, 0.0
+        elif self.mode == WalkModes.FORWARD:
+            yaw_vel_ref = 0.0
+        goal_vel_xy = np.array([vx_ref, vy_ref])
+        goal_speed = float(np.linalg.norm(goal_vel_xy))
 
-        # Calculate rewards with explicit parameters
         reward = dict(
             foot_frc_score=0.225
             * rewards.calc_foot_frc_clock_reward(l_foot_frc, r_foot_frc, self._phase, l_frc_fn, r_frc_fn, self._mass),
@@ -128,11 +136,11 @@ class WalkingTask(BaseTask):
             * rewards.calc_foot_vel_clock_reward(l_foot_vel, r_foot_vel, self._phase, l_vel_fn, r_vel_fn),
             root_accel=0.050 * rewards.calc_root_accel_reward(qvel, qacc),
             height_error=0.050
-            * rewards.calc_height_reward(root_height, self._goal_height_ref, self._goal_speed_ref, contact_point_z),
-            com_vel_error=0.150 * rewards.calc_fwd_vel_reward(root_vel, self._goal_speed_ref),
+            * rewards.calc_height_reward(root_height, self._goal_height_ref, goal_speed, contact_point_z),
+            com_vel_error=0.150 * rewards.calc_fwd_vel_reward(root_vel_xy, goal_vel_xy),
             yaw_vel_error=0.150 * rewards.calc_yaw_vel_reward(yaw_vel, yaw_vel_ref),
             upper_body_reward=0.050 * np.exp(-10 * np.linalg.norm(head_pos - root_pos)),
-            posture_error=0.050 * np.exp(-np.linalg.norm(self._neutral_pose[:12] - current_pose[:12])),
+            posture_error=0.050 * np.exp(-np.linalg.norm(self._neutral_pose - current_pose)),
             torque_penalty=0.025 * rewards.calc_torque_reward(current_torque, prev_torque),
             action_penalty=0.025 * rewards.calc_action_reward(action, prev_action),
         )
@@ -144,7 +152,7 @@ class WalkingTask(BaseTask):
         if self._phase >= self._period:
             self._phase = 0
 
-        # random switch between INPLACE and STANDING( (only in double support)
+        # random switch between INPLACE and STANDING (only in double support)
         in_double_support = self.right_clock[0](self._phase) == 1 and self.left_clock[0](self._phase) == 1
         if np.random.randint(100) == 0 and in_double_support:
             if self.mode == WalkModes.INPLACE:
@@ -169,7 +177,6 @@ class WalkingTask(BaseTask):
                     np.random.uniform(-0.5, 0.5),
                     np.random.uniform(-0.015, -0.035),
                 ]
-        return
 
     def substep(self) -> None:
         pass
@@ -182,12 +189,9 @@ class WalkingTask(BaseTask):
             "qpos[2]_ul": (qpos[2] > 1.4),
             "contact_flag": contact_flag,
         }
-
-        done = True in terminate_conditions.values()
-        return done
+        return True in terminate_conditions.values()
 
     def reset(self, iter_count=0):
-        # select a walking 'mode'
         self.mode = np.random.choice([WalkModes.STANDING, WalkModes.INPLACE, WalkModes.FORWARD], p=[0.6, 0.2, 0.2])
         self.mode_ref = self.mode.sample_ref()
 
@@ -198,5 +202,4 @@ class WalkingTask(BaseTask):
         # number of control steps in one full cycle
         # (one full cycle includes left swing + right swing)
         self._period = np.floor(2 * self._total_duration * (1 / self._control_dt))
-        # randomize phase during initialization
         self._phase = np.random.randint(0, self._period)


### PR DESCRIPTION
Port H1WalkEnv and unify the walking task
so it works for both JVRC and H1 (and future bipeds). mode_ref is now a
3-D [yaw_vel, vx, vy] reference; envs supply only the actuated-joint
neutral pose. JVRC's external obs grows from 6 to 8 to match.