### PR TITLE
Refactor PPO imitation loss behind env-owned adapter

### DIFF
--- a/rl/algos/imitation.py
+++ b/rl/algos/imitation.py
@@ -1,0 +1,41 @@
+"""Contract for env-owned imitation-loss adapters.
+
+PPO needs to ask "for this batch of policy obs, what should I feed an expert and
+what should I compare its output against?" without knowing anything about the
+env's obs/action layout. The env answers via an :class:`ImitationAdapter` it
+returns from ``env.imitation_adapter()``.
+"""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import torch
+
+
+@dataclass
+class ImitationQuery:
+    """One batched question to the expert.
+
+    Attributes:
+        expert_obs: ``(N_active, expert_obs_dim)`` tensor — already filtered to the
+            samples that should contribute to the loss. Callers pass this straight
+            into ``base_policy(...)``.
+        sample_mask: ``(B,)`` bool tensor — which entries of the original policy
+            obs batch fed the expert. Used to select the matching student actions.
+        action_indices: ``(k,)`` long tensor — which student-action dims to
+            compare against the expert's output.
+    """
+
+    expert_obs: torch.Tensor
+    sample_mask: torch.Tensor
+    action_indices: torch.Tensor
+
+
+class ImitationAdapter(Protocol):
+    """Translator from policy obs to an expert query.
+
+    Implementations are stateless w.r.t. env time: they capture obs-layout
+    constants at construction and operate purely on the obs batch tensor.
+    """
+
+    def __call__(self, obs_batch: torch.Tensor) -> ImitationQuery: ...

--- a/rl/algos/imitation.py
+++ b/rl/algos/imitation.py
@@ -1,9 +1,9 @@
-"""Contract for env-owned imitation-loss adapters.
+"""Contract for env-owned imitation-loss projectors.
 
 PPO needs to ask "for this batch of policy obs, what should I feed an expert and
 what should I compare its output against?" without knowing anything about the
-env's obs/action layout. The env answers via an :class:`ImitationAdapter` it
-returns from ``env.imitation_adapter()``.
+env's obs/action layout. The env answers via an :class:`ImitationProjector` it
+returns from ``env.imitation_projector()``.
 """
 
 from dataclasses import dataclass
@@ -31,8 +31,9 @@ class ImitationQuery:
     action_indices: torch.Tensor
 
 
-class ImitationAdapter(Protocol):
-    """Translator from policy obs to an expert query.
+class ImitationProjector(Protocol):
+    """Projects policy obs into the expert's input space and selects which
+    samples / action dims contribute to the imitation loss.
 
     Implementations are stateless w.r.t. env time: they capture obs-layout
     constants at construction and operate purely on the obs batch tensor.

--- a/rl/algos/ppo.py
+++ b/rl/algos/ppo.py
@@ -109,16 +109,16 @@ class PPO:
                 critic.obs_std = policy.obs_std
 
         base_policy = None
-        imitation_adapter = None
+        imitation_projector = None
         if args.imitate:
             base_policy = torch.load(args.imitate, weights_only=False)
             base_policy.eval()
-            adapter_factory = getattr(env_instance, "imitation_adapter", None)
-            imitation_adapter = adapter_factory() if callable(adapter_factory) else None
-            if imitation_adapter is None:
+            projector_factory = getattr(env_instance, "imitation_projector", None)
+            imitation_projector = projector_factory() if callable(projector_factory) else None
+            if imitation_projector is None:
                 raise ValueError(
                     f"--imitate was passed but env {type(env_instance).__name__} does "
-                    "not implement imitation_adapter(); cannot construct expert query."
+                    "not implement imitation_projector(); cannot construct expert query."
                 )
 
         # Device setup (from args or auto-detect)
@@ -153,7 +153,7 @@ class PPO:
         self.policy = policy
         self.critic = critic
         self.base_policy = base_policy
-        self.imitation_adapter = imitation_adapter
+        self.imitation_projector = imitation_projector
 
         # Store env_fn for later use
         self.env_fn = env_fn
@@ -359,8 +359,8 @@ class PPO:
 
         # imitation loss
         imitation_loss = torch.zeros_like(actor_loss)
-        if self.imitation_adapter is not None:
-            query = self.imitation_adapter(obs_batch)
+        if self.imitation_projector is not None:
+            query = self.imitation_projector(obs_batch)
             if query.sample_mask.any():
                 with torch.no_grad():
                     target = self.base_policy(query.expert_obs)

--- a/rl/algos/ppo.py
+++ b/rl/algos/ppo.py
@@ -109,8 +109,17 @@ class PPO:
                 critic.obs_std = policy.obs_std
 
         base_policy = None
+        imitation_adapter = None
         if args.imitate:
             base_policy = torch.load(args.imitate, weights_only=False)
+            base_policy.eval()
+            adapter_factory = getattr(env_instance, "imitation_adapter", None)
+            imitation_adapter = adapter_factory() if callable(adapter_factory) else None
+            if imitation_adapter is None:
+                raise ValueError(
+                    f"--imitate was passed but env {type(env_instance).__name__} does "
+                    "not implement imitation_adapter(); cannot construct expert query."
+                )
 
         # Device setup (from args or auto-detect)
         device_arg = getattr(args, "device", "auto")
@@ -144,6 +153,7 @@ class PPO:
         self.policy = policy
         self.critic = critic
         self.base_policy = base_policy
+        self.imitation_adapter = imitation_adapter
 
         # Store env_fn for later use
         self.env_fn = env_fn
@@ -348,10 +358,14 @@ class PPO:
             mirror_loss = torch.zeros_like(actor_loss)
 
         # imitation loss
-        if self.base_policy is not None:
-            imitation_loss = (self.base_policy(obs_batch) - deterministic_actions).pow(2).mean()
-        else:
-            imitation_loss = torch.zeros_like(actor_loss)
+        imitation_loss = torch.zeros_like(actor_loss)
+        if self.imitation_adapter is not None:
+            query = self.imitation_adapter(obs_batch)
+            if query.sample_mask.any():
+                with torch.no_grad():
+                    target = self.base_policy(query.expert_obs)
+                pred = deterministic_actions[query.sample_mask][:, query.action_indices]
+                imitation_loss = (pred - target).pow(2).mean()
 
         # Calculate approximate form of reverse KL Divergence for early stopping
         # see issue #417: https://github.com/DLR-RM/stable-baselines3/issues/417

--- a/tests/test_imitation.py
+++ b/tests/test_imitation.py
@@ -1,0 +1,195 @@
+"""Tests for the env-owned imitation-adapter contract.
+
+Covers:
+- PPO loads ``env.imitation_adapter()`` when ``--imitate`` is set.
+- ``update_actor_critic`` produces a finite imitation loss when the adapter's
+  mask is non-empty, and zero when the mask is empty.
+- PPO raises a clear error when ``--imitate`` is set against an env that does
+  not implement ``imitation_adapter()``.
+"""
+
+from argparse import Namespace
+from functools import partial
+
+import pytest
+import torch
+import torch.optim as optim
+
+from envs import ENVIRONMENTS
+from rl.algos.imitation import ImitationQuery
+from rl.algos.ppo import PPO
+from rl.policies.actor import Gaussian_FF_Actor
+
+CARTPOLE_OBS_DIM = 5
+CARTPOLE_ACT_DIM = 1
+
+
+class _StubAdapter:
+    """Minimal adapter for tests: slice obs[:, :expert_obs_dim], mask sin(obs[:,0])>0."""
+
+    def __init__(self, expert_obs_dim: int, action_indices: list[int], mask_thresh: float = 0.0):
+        self._expert_obs_dim = expert_obs_dim
+        self._action_indices = torch.tensor(action_indices, dtype=torch.long)
+        self._mask_thresh = mask_thresh
+
+    def __call__(self, obs_batch: torch.Tensor) -> ImitationQuery:
+        mask = obs_batch[:, 0] > self._mask_thresh
+        sliced = obs_batch[:, : self._expert_obs_dim]
+        return ImitationQuery(
+            expert_obs=sliced[mask],
+            sample_mask=mask,
+            action_indices=self._action_indices.to(obs_batch.device),
+        )
+
+
+class _AlwaysEmptyAdapter:
+    """Adapter whose mask is always all-False; exercises the fast-path branch."""
+
+    def __init__(self, expert_obs_dim: int, action_indices: list[int]):
+        self._expert_obs_dim = expert_obs_dim
+        self._action_indices = torch.tensor(action_indices, dtype=torch.long)
+
+    def __call__(self, obs_batch: torch.Tensor) -> ImitationQuery:
+        mask = torch.zeros(obs_batch.shape[0], dtype=torch.bool, device=obs_batch.device)
+        return ImitationQuery(
+            expert_obs=obs_batch[:0, : self._expert_obs_dim],
+            sample_mask=mask,
+            action_indices=self._action_indices.to(obs_batch.device),
+        )
+
+
+def _save_dummy_expert(path, expert_obs_dim: int, expert_action_dim: int) -> None:
+    expert = Gaussian_FF_Actor(
+        state_dim=expert_obs_dim,
+        action_dim=expert_action_dim,
+        layers=(16,),
+        init_std=0.2,
+        learn_std=False,
+    )
+    torch.save(expert, path)
+
+
+def _train_args(logdir, imitate_path=None) -> Namespace:
+    return Namespace(
+        env="cartpole",
+        logdir=logdir,
+        lr=1e-4,
+        eps=1e-5,
+        lam=0.95,
+        gamma=0.99,
+        std_dev=0.223,
+        learn_std=False,
+        entropy_coeff=0.0,
+        clip=0.2,
+        minibatch_size=32,
+        epochs=1,
+        use_gae=True,
+        num_procs=2,
+        max_grad_norm=0.05,
+        max_traj_len=50,
+        no_mirror=True,
+        mirror_coeff=0.0,
+        eval_freq=100,
+        continued=None,
+        recurrent=False,
+        imitate=imitate_path,
+        imitate_coeff=0.3,
+        yaml=None,
+        input_norm_steps=100,
+        device="cpu",
+    )
+
+
+def _cartpole_factory():
+    env_cls, _ = ENVIRONMENTS["cartpole"]
+    return partial(env_cls, path_to_yaml=None)
+
+
+def _attach_adapter(env_cls, adapter):
+    """Patch a class-level ``imitation_adapter()`` returning ``adapter``."""
+    env_cls.imitation_adapter = lambda self, _a=adapter: _a
+
+
+def _detach_adapter(env_cls):
+    if "imitation_adapter" in env_cls.__dict__:
+        delattr(env_cls, "imitation_adapter")
+
+
+def _synthetic_batch(ppo, batch_size=8):
+    obs_dim = ppo.policy.state_dim
+    action_dim = ppo.policy.action_dim
+    obs = torch.randn(batch_size, obs_dim)
+    actions = torch.randn(batch_size, action_dim)
+    returns = torch.randn(batch_size, 1)
+    advantages = torch.randn(batch_size, 1)
+    return obs, actions, returns, advantages
+
+
+def _set_optimizers(ppo):
+    ppo.actor_optimizer = optim.Adam(ppo.policy.parameters(), lr=ppo.lr, eps=ppo.eps)
+    ppo.critic_optimizer = optim.Adam(ppo.critic.parameters(), lr=ppo.lr, eps=ppo.eps)
+
+
+def test_adapter_drives_imitation_loss(tmp_path):
+    """Adapter with a non-empty mask produces a finite, non-zero imitation loss."""
+    expert_path = tmp_path / "expert.pt"
+    _save_dummy_expert(expert_path, expert_obs_dim=3, expert_action_dim=CARTPOLE_ACT_DIM)
+
+    env_cls, _ = ENVIRONMENTS["cartpole"]
+    adapter = _StubAdapter(expert_obs_dim=3, action_indices=[0])
+    _attach_adapter(env_cls, adapter)
+    try:
+        args = _train_args(tmp_path, imitate_path=str(expert_path))
+        ppo = PPO(_cartpole_factory(), args)
+
+        assert ppo.imitation_adapter is adapter
+        assert ppo.base_policy is not None
+
+        _set_optimizers(ppo)
+
+        # Force a deterministic mask hit by writing a positive value into obs[:, 0]
+        obs, actions, returns, advantages = _synthetic_batch(ppo)
+        obs[:, 0] = 1.0  # all samples pass the stub's mask
+
+        scalars = ppo.update_actor_critic(obs, actions, returns, advantages, mask=1)
+        imitation_loss = scalars[5]
+
+        assert torch.isfinite(imitation_loss)
+        assert imitation_loss.item() > 0.0
+    finally:
+        _detach_adapter(env_cls)
+
+
+def test_empty_mask_yields_zero_loss(tmp_path):
+    """Adapter that masks out every sample short-circuits to zero loss."""
+    expert_path = tmp_path / "expert.pt"
+    _save_dummy_expert(expert_path, expert_obs_dim=3, expert_action_dim=CARTPOLE_ACT_DIM)
+
+    env_cls, _ = ENVIRONMENTS["cartpole"]
+    _attach_adapter(env_cls, _AlwaysEmptyAdapter(expert_obs_dim=3, action_indices=[0]))
+    try:
+        args = _train_args(tmp_path, imitate_path=str(expert_path))
+        ppo = PPO(_cartpole_factory(), args)
+        _set_optimizers(ppo)
+
+        obs, actions, returns, advantages = _synthetic_batch(ppo)
+        scalars = ppo.update_actor_critic(obs, actions, returns, advantages, mask=1)
+        imitation_loss = scalars[5]
+
+        assert torch.isfinite(imitation_loss)
+        assert imitation_loss.item() == 0.0
+    finally:
+        _detach_adapter(env_cls)
+
+
+def test_missing_adapter_raises(tmp_path):
+    """--imitate against an env without imitation_adapter() raises a clear error."""
+    expert_path = tmp_path / "expert.pt"
+    _save_dummy_expert(expert_path, expert_obs_dim=3, expert_action_dim=CARTPOLE_ACT_DIM)
+
+    env_cls, _ = ENVIRONMENTS["cartpole"]
+    _detach_adapter(env_cls)  # ensure no leftover patch from another test
+
+    args = _train_args(tmp_path, imitate_path=str(expert_path))
+    with pytest.raises(ValueError, match="imitation_adapter"):
+        PPO(_cartpole_factory(), args)

--- a/tests/test_imitation.py
+++ b/tests/test_imitation.py
@@ -1,11 +1,11 @@
-"""Tests for the env-owned imitation-adapter contract.
+"""Tests for the env-owned imitation-projector contract.
 
 Covers:
-- PPO loads ``env.imitation_adapter()`` when ``--imitate`` is set.
-- ``update_actor_critic`` produces a finite imitation loss when the adapter's
+- PPO loads ``env.imitation_projector()`` when ``--imitate`` is set.
+- ``update_actor_critic`` produces a finite imitation loss when the projector's
   mask is non-empty, and zero when the mask is empty.
 - PPO raises a clear error when ``--imitate`` is set against an env that does
-  not implement ``imitation_adapter()``.
+  not implement ``imitation_projector()``.
 """
 
 from argparse import Namespace
@@ -24,8 +24,8 @@ CARTPOLE_OBS_DIM = 5
 CARTPOLE_ACT_DIM = 1
 
 
-class _StubAdapter:
-    """Minimal adapter for tests: slice obs[:, :expert_obs_dim], mask sin(obs[:,0])>0."""
+class _StubProjector:
+    """Minimal projector for tests: slice obs[:, :expert_obs_dim], mask sin(obs[:,0])>0."""
 
     def __init__(self, expert_obs_dim: int, action_indices: list[int], mask_thresh: float = 0.0):
         self._expert_obs_dim = expert_obs_dim
@@ -42,8 +42,8 @@ class _StubAdapter:
         )
 
 
-class _AlwaysEmptyAdapter:
-    """Adapter whose mask is always all-False; exercises the fast-path branch."""
+class _AlwaysEmptyProjector:
+    """Projector whose mask is always all-False; exercises the fast-path branch."""
 
     def __init__(self, expert_obs_dim: int, action_indices: list[int]):
         self._expert_obs_dim = expert_obs_dim
@@ -105,14 +105,14 @@ def _cartpole_factory():
     return partial(env_cls, path_to_yaml=None)
 
 
-def _attach_adapter(env_cls, adapter):
-    """Patch a class-level ``imitation_adapter()`` returning ``adapter``."""
-    env_cls.imitation_adapter = lambda self, _a=adapter: _a
+def _attach_projector(env_cls, projector):
+    """Patch a class-level ``imitation_projector()`` returning ``projector``."""
+    env_cls.imitation_projector = lambda self, _p=projector: _p
 
 
-def _detach_adapter(env_cls):
-    if "imitation_adapter" in env_cls.__dict__:
-        delattr(env_cls, "imitation_adapter")
+def _detach_projector(env_cls):
+    if "imitation_projector" in env_cls.__dict__:
+        delattr(env_cls, "imitation_projector")
 
 
 def _synthetic_batch(ppo, batch_size=8):
@@ -130,19 +130,19 @@ def _set_optimizers(ppo):
     ppo.critic_optimizer = optim.Adam(ppo.critic.parameters(), lr=ppo.lr, eps=ppo.eps)
 
 
-def test_adapter_drives_imitation_loss(tmp_path):
-    """Adapter with a non-empty mask produces a finite, non-zero imitation loss."""
+def test_projector_drives_imitation_loss(tmp_path):
+    """Projector with a non-empty mask produces a finite, non-zero imitation loss."""
     expert_path = tmp_path / "expert.pt"
     _save_dummy_expert(expert_path, expert_obs_dim=3, expert_action_dim=CARTPOLE_ACT_DIM)
 
     env_cls, _ = ENVIRONMENTS["cartpole"]
-    adapter = _StubAdapter(expert_obs_dim=3, action_indices=[0])
-    _attach_adapter(env_cls, adapter)
+    projector = _StubProjector(expert_obs_dim=3, action_indices=[0])
+    _attach_projector(env_cls, projector)
     try:
         args = _train_args(tmp_path, imitate_path=str(expert_path))
         ppo = PPO(_cartpole_factory(), args)
 
-        assert ppo.imitation_adapter is adapter
+        assert ppo.imitation_projector is projector
         assert ppo.base_policy is not None
 
         _set_optimizers(ppo)
@@ -157,16 +157,16 @@ def test_adapter_drives_imitation_loss(tmp_path):
         assert torch.isfinite(imitation_loss)
         assert imitation_loss.item() > 0.0
     finally:
-        _detach_adapter(env_cls)
+        _detach_projector(env_cls)
 
 
 def test_empty_mask_yields_zero_loss(tmp_path):
-    """Adapter that masks out every sample short-circuits to zero loss."""
+    """Projector that masks out every sample short-circuits to zero loss."""
     expert_path = tmp_path / "expert.pt"
     _save_dummy_expert(expert_path, expert_obs_dim=3, expert_action_dim=CARTPOLE_ACT_DIM)
 
     env_cls, _ = ENVIRONMENTS["cartpole"]
-    _attach_adapter(env_cls, _AlwaysEmptyAdapter(expert_obs_dim=3, action_indices=[0]))
+    _attach_projector(env_cls, _AlwaysEmptyProjector(expert_obs_dim=3, action_indices=[0]))
     try:
         args = _train_args(tmp_path, imitate_path=str(expert_path))
         ppo = PPO(_cartpole_factory(), args)
@@ -179,17 +179,17 @@ def test_empty_mask_yields_zero_loss(tmp_path):
         assert torch.isfinite(imitation_loss)
         assert imitation_loss.item() == 0.0
     finally:
-        _detach_adapter(env_cls)
+        _detach_projector(env_cls)
 
 
-def test_missing_adapter_raises(tmp_path):
-    """--imitate against an env without imitation_adapter() raises a clear error."""
+def test_missing_projector_raises(tmp_path):
+    """--imitate against an env without imitation_projector() raises a clear error."""
     expert_path = tmp_path / "expert.pt"
     _save_dummy_expert(expert_path, expert_obs_dim=3, expert_action_dim=CARTPOLE_ACT_DIM)
 
     env_cls, _ = ENVIRONMENTS["cartpole"]
-    _detach_adapter(env_cls)  # ensure no leftover patch from another test
+    _detach_projector(env_cls)  # ensure no leftover patch from another test
 
     args = _train_args(tmp_path, imitate_path=str(expert_path))
-    with pytest.raises(ValueError, match="imitation_adapter"):
+    with pytest.raises(ValueError, match="imitation_projector"):
         PPO(_cartpole_factory(), args)


### PR DESCRIPTION
PPO no longer hardcodes obs/action layout for the expert. Envs that support imitation return an ImitationProjector from `imitation_projector()`; PPO calls it on each minibatch to get expert obs, sample mask, and action indices. --imitate without an adapter raises clearly.